### PR TITLE
[SEARCH] fix systematic reindexing of record json field

### DIFF
--- a/front/app/svelte/src/witness/ViewerIframe.svelte
+++ b/front/app/svelte/src/witness/ViewerIframe.svelte
@@ -1,23 +1,19 @@
 <script>
-    import { onMount } from "svelte";
-    import { manifestToMirador } from "../utils.js";
+    import {onMount} from "svelte";
+    import {manifestToMirador} from "../utils.js";
 
     let iframeSrc = "";
 
     onMount(() => {
-      if (manifests.length > 0) iframeSrc = manifestToMirador(manifests[0]);
+        if (manifests.length > 0) iframeSrc = manifestToMirador(manifests[0]);
 
-      function handler(e) {
-        iframeSrc = manifestToMirador(e.detail.selectedManifest);
-      }
+        function handler(e) {
+            iframeSrc = manifestToMirador(e.detail.selectedManifest);
+        }
 
-      window.addEventListener("selectManifest", handler);
+        window.addEventListener("selectManifest", handler);
     });
 </script>
 
-<iframe
-    src={iframeSrc}
-    style="width: 100%; height: 75vh; border: none;"
-    title="Mirador viewer"
-    allowfullscreen
-></iframe>
+<iframe src={iframeSrc} style="width: 100%; height: 75vh; border: none;"
+        title="Mirador viewer" allowfullscreen/>

--- a/front/app/svelte/src/witness/WitnessBtn.svelte
+++ b/front/app/svelte/src/witness/WitnessBtn.svelte
@@ -13,7 +13,7 @@
     }
 
     function manifestLabel(url) {
-        const manifest = url.match(/man(\d+)/);
+        const manifest = url.match(/(?:man|img|pdf)(\d+)/);
         const manifestId = manifest ? manifest[1] : "?";
 
         const regionsExtId = url.match(/anno(\d+)/);

--- a/front/app/svelte/src/witness/WitnessView.svelte
+++ b/front/app/svelte/src/witness/WitnessView.svelte
@@ -1,6 +1,5 @@
 <script>
     import { setContext } from "svelte";
-    import { fade } from 'svelte/transition';
     import { refToIIIF, loading } from "../utils.js";
     import { appLang, regionsType, modules } from "../constants";
 

--- a/front/app/webapp/models/content.py
+++ b/front/app/webapp/models/content.py
@@ -135,10 +135,6 @@ class Content(models.Model):
     )
 
     def get_metadata(self):
-        metadata = {
-            "title": f"{self.work.__str__()} ({self.get_formatted_pages() if self.page_max and self.page_min else '-'})",
-        }
-
         content = {}
 
         if self.date_max and self.date_min:
@@ -153,9 +149,11 @@ class Content(models.Model):
         if self.get_roles():
             content[get_name("roles")] = self.get_str_roles()
 
-        metadata["content"] = content
-
-        return metadata
+        work_title = self.work.__str__() if self.work else "Unknown Work"
+        return {
+            "title": f"{work_title} ({self.get_formatted_pages()})",
+            "content": content,
+        }
 
     def get_witness(self):
         try:
@@ -171,9 +169,11 @@ class Content(models.Model):
 
     def get_formatted_pages(self):
         if self.page_min == "" and self.page_max == "":
-            return ""
+            return "-"
 
-        page_t = "pp." if self.get_witness().page_type == PAG_ABBR else "ff."
+        page_t = ""
+        if wit := self.get_witness():
+            page_t = "pp. " if wit.get_page_type() == PAG_ABBR else "ff. "
         return f"{page_t} {format_start_end(self.page_min, self.page_max)}"
 
     def get_nb_of_page(self, only_nb=True):

--- a/front/app/webapp/models/content.py
+++ b/front/app/webapp/models/content.py
@@ -26,6 +26,7 @@ from app.webapp.utils.functions import (
     flatten,
 )
 from app.webapp.utils.logger import log
+from config.settings import APP_LANG
 
 
 def get_name(fieldname, plural=False):
@@ -173,8 +174,12 @@ class Content(models.Model):
 
         page_t = ""
         if wit := self.get_witness():
-            page_t = "pp. " if wit.get_page_type() == PAG_ABBR else "ff. "
-        return f"{page_t} {format_start_end(self.page_min, self.page_max)}"
+            page_t = "pp. " if wit.page_type == PAG_ABBR else "ff. "
+
+        if self.whole_witness:
+            return f"Entire {WIT}" if APP_LANG == "en" else f"Intégralité du {WIT}"
+
+        return f"{page_t}{format_start_end(self.page_min, self.page_max)}"
 
     def get_nb_of_page(self, only_nb=True):
         wit = self.get_witness()

--- a/front/app/webapp/models/content.py
+++ b/front/app/webapp/models/content.py
@@ -26,7 +26,7 @@ from app.webapp.utils.functions import (
     flatten,
 )
 from app.webapp.utils.logger import log
-from config.settings import APP_LANG
+from app.config.settings import APP_LANG
 
 
 def get_name(fieldname, plural=False):

--- a/front/app/webapp/models/searchable_models.py
+++ b/front/app/webapp/models/searchable_models.py
@@ -84,9 +84,9 @@ class AbstractSearchableModel(models.Model):
 
         if full_metadata and "metadata_full" not in json_data:
             if hasattr(self, "get_full_metadata"):
-                json_data["metadata_full"] = self.get_full_metadata(json_data)
+                json_data["metadata_full"] = self.get_full_metadata()
 
-        return self.json
+        return json_data
 
     def is_key_defined(self, key):
         return not (not self.json or key not in self.json or not self.json[key])

--- a/front/app/webapp/models/searchable_models.py
+++ b/front/app/webapp/models/searchable_models.py
@@ -42,6 +42,7 @@ class AbstractSearchableModel(models.Model):
         reindex and no_img are used in subclasses to_json methods
         reindex: force recomputing all properties, even the one that require intensive computation
         no_img: if True, do not index image related property
+        TODO delete request_user (should only be handled by get_json and not persisted in db)
         """
         try:
             return json_encode(
@@ -69,11 +70,19 @@ class AbstractSearchableModel(models.Model):
         Get the JSON representation of the object.
         If reindex is True or json property hasn't been generated yet,
         generate the JSON and update the database.
+        If request_user is provided, enrich with can_edit without reindexing.
         """
         if not self.json or reindex:
+            # NOTE to_json should probably not use request_user to not index in db can_edit value which is user-dependant
             json_data = self.to_json(reindex=True, request_user=request_user)
             type(self).objects.filter(pk=self.pk.__str__()).update(json=json_data)
             return json_data
+
+        if request_user and hasattr(self, "can_edit"):
+            json_data = self.json.copy()
+            json_data["can_edit"] = self.can_edit(request_user)
+            return json_data
+
         return self.json
 
     def is_key_defined(self, key):

--- a/front/app/webapp/models/searchable_models.py
+++ b/front/app/webapp/models/searchable_models.py
@@ -65,7 +65,7 @@ class AbstractSearchableModel(models.Model):
     def update(self, **kwargs):
         type(self).objects.filter(pk=self.pk.__str__()).update(**kwargs)
 
-    def get_json(self, reindex=False, request_user=None):
+    def get_json(self, reindex=False, request_user=None, full_metadata=False):
         """
         Get the JSON representation of the object.
         If reindex is True or json property hasn't been generated yet,
@@ -78,10 +78,13 @@ class AbstractSearchableModel(models.Model):
             type(self).objects.filter(pk=self.pk.__str__()).update(json=json_data)
             return json_data
 
+        json_data = self.json.copy()
         if request_user and hasattr(self, "can_edit"):
-            json_data = self.json.copy()
             json_data["can_edit"] = self.can_edit(request_user)
-            return json_data
+
+        if full_metadata and "metadata_full" not in json_data:
+            if hasattr(self, "get_full_metadata"):
+                json_data["metadata_full"] = self.get_full_metadata(json_data)
 
         return self.json
 

--- a/front/app/webapp/models/witness.py
+++ b/front/app/webapp/models/witness.py
@@ -25,6 +25,7 @@ from app.webapp.models.utils.constants import (
     FOL_ABBR,
     NO_USER,
     MS_ABBR,
+    MS,
 )
 from app.webapp.models.utils.functions import get_fieldname
 from app.webapp.models.work import Work
@@ -270,10 +271,10 @@ class Witness(AbstractSearchableModel):
 
     def get_type(self):
         # NOTE should be returning "letterpress" (tpr) / "woodblock" (wpr) / "manuscript" (ms)
-        return MAP_WIT_TYPE.get(self.type, MS_ABBR)
+        return MAP_WIT_TYPE.get(self.type, MS.capitalize())
 
     def get_page_type(self):
-        return MAP_PAGE_TYPE.get(self.page_type, PAG_ABBR)
+        return MAP_PAGE_TYPE.get(self.page_type, PAGE.capitalize())
 
     def get_ref(self):
         return f"wit{self.id}"

--- a/front/app/webapp/models/witness.py
+++ b/front/app/webapp/models/witness.py
@@ -270,10 +270,10 @@ class Witness(AbstractSearchableModel):
 
     def get_type(self):
         # NOTE should be returning "letterpress" (tpr) / "woodblock" (wpr) / "manuscript" (ms)
-        return MAP_WIT_TYPE[self.type]
+        return MAP_WIT_TYPE.get(self.type, MS_ABBR)
 
     def get_page_type(self):
-        return MAP_PAGE_TYPE[self.page_type]
+        return MAP_PAGE_TYPE.get(self.page_type, PAG_ABBR)
 
     def get_ref(self):
         return f"wit{self.id}"

--- a/front/app/webapp/models/witness.py
+++ b/front/app/webapp/models/witness.py
@@ -245,7 +245,7 @@ class Witness(AbstractSearchableModel):
             "link": self.get_link(),
         }
 
-        if self.type != "ms":
+        if self.type != MS_ABBR:
             wit["edition"] = self.get_edition()
             wit["volume_nb"] = self.get_volume_nb()
             wit["volume_title"] = self.get_volume_title()
@@ -352,6 +352,7 @@ class Witness(AbstractSearchableModel):
         )
         if len(wit_dates) == 1:
             return None, wit_dates[0]
+
         return (min(wit_dates), max(wit_dates)) if wit_dates else (None, None)
 
     def get_contents(self):

--- a/front/app/webapp/models/witness.py
+++ b/front/app/webapp/models/witness.py
@@ -199,6 +199,10 @@ class Witness(AbstractSearchableModel):
         if not no_img and (reindex or not img):
             img = self.get_img(only_first=True)
 
+        updated = (
+            self.updated_at.strftime("%Y-%m-%d %H:%M") if self.updated_at else None
+        )
+
         return json_encode(
             {
                 "id": self.id,
@@ -215,9 +219,7 @@ class Witness(AbstractSearchableModel):
                 "view_url": self.get_absolute_view_url(),
                 # NOTE handled dynamically by the get_json method in SearchableModel
                 "can_edit": self.can_edit(request_user),
-                "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M")
-                if self.updated_at
-                else None,
+                "updated_at": updated,
                 "is_public": self.is_public,
                 "metadata": {
                     get_name("id_nb"): self.id_nb or "-",
@@ -227,12 +229,12 @@ class Witness(AbstractSearchableModel):
                     get_name("page_nb"): self.get_page(),
                     get_name("Language"): self.get_lang_names(),
                 },
-                "metadata_full": self.get_wit_metadata(),
+                "metadata_full": self.get_full_metadata(),
                 "buttons": buttons,
             }
         )
 
-    def get_wit_metadata(self):
+    def get_full_metadata(self):
         metadata = {}
 
         wit = {

--- a/front/app/webapp/models/witness.py
+++ b/front/app/webapp/models/witness.py
@@ -213,8 +213,11 @@ class Witness(AbstractSearchableModel):
                 "user": user.__str__() if user else NO_USER,
                 "edit_url": self.get_absolute_edit_url(),
                 "view_url": self.get_absolute_view_url(),
+                # NOTE handled dynamically by the get_json method in SearchableModel
                 "can_edit": self.can_edit(request_user),
-                "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M"),
+                "updated_at": self.updated_at.strftime("%Y-%m-%d %H:%M")
+                if self.updated_at
+                else None,
                 "is_public": self.is_public,
                 "metadata": {
                     get_name("id_nb"): self.id_nb or "-",

--- a/front/app/webapp/views/admin.py
+++ b/front/app/webapp/views/admin.py
@@ -192,9 +192,7 @@ class WitnessRegionsView(AbstractRecordView):
 
         witness = self.get_record()
         context["view_title"] = f"{witness}"
-        context["witness"] = witness.get_json(
-            reindex=True, request_user=self.request.user
-        )
+        context["witness"] = witness.get_json(request_user=self.request.user)
         if len(context["witness"]["digits"]) == 0:
             # TODO handle case where no digitization is available
             pass

--- a/front/app/webapp/views/admin.py
+++ b/front/app/webapp/views/admin.py
@@ -203,11 +203,11 @@ class WitnessRegionsView(AbstractRecordView):
         context["manifests"] = []
 
         for did in context["witness"]["digits"]:
-            if digit := Digitization.objects.get(pk=did):
+            if digit := Digitization.objects.filter(pk=did).first():
                 context["manifests"].append(digit.gen_manifest_url(version=MANIFEST_V2))
 
         for rid in context["witness"]["regions"]:
-            regions = Regions.objects.get(pk=rid)
+            regions = Regions.objects.filter(pk=rid).first()
             if not regions:
                 continue
 
@@ -217,7 +217,7 @@ class WitnessRegionsView(AbstractRecordView):
             # TODO handle multiple manifest for multiple regions
 
             man = regions.gen_manifest_url(version=MANIFEST_V2)
-            context["manifest"] = man
+            context["manifest"] = man  # overwritten at each iteration
             context["manifests"].append(man)
 
             context["img_prefix"] = regions.get_ref().split("_anno")[0]

--- a/front/app/webapp/views/admin.py
+++ b/front/app/webapp/views/admin.py
@@ -192,7 +192,10 @@ class WitnessRegionsView(AbstractRecordView):
 
         witness = self.get_record()
         context["view_title"] = f"{witness}"
-        context["witness"] = witness.get_json(request_user=self.request.user)
+        context["witness"] = witness.get_json(
+            request_user=self.request.user,
+            full_metadata=True,
+        )
         if len(context["witness"]["digits"]) == 0:
             # TODO handle case where no digitization is available
             pass

--- a/front/app/webapp/views/admin.py
+++ b/front/app/webapp/views/admin.py
@@ -203,18 +203,22 @@ class WitnessRegionsView(AbstractRecordView):
         context["manifests"] = []
 
         for did in context["witness"]["digits"]:
-            digit = Digitization.objects.get(pk=did)
-            context["manifests"].append(digit.gen_manifest_url(version=MANIFEST_V2))
+            if digit := Digitization.objects.get(pk=did):
+                context["manifests"].append(digit.gen_manifest_url(version=MANIFEST_V2))
 
         for rid in context["witness"]["regions"]:
             regions = Regions.objects.get(pk=rid)
+            if not regions:
+                continue
+
             context["regions_ids"].append(rid)
             # for regions in witness.get_regions():
             #     context["regions_ids"].append(regions.id)
             # TODO handle multiple manifest for multiple regions
 
-            context["manifest"] = regions.gen_manifest_url(version=MANIFEST_V2)
-            context["manifests"].append(regions.gen_manifest_url(version=MANIFEST_V2))
+            man = regions.gen_manifest_url(version=MANIFEST_V2)
+            context["manifest"] = man
+            context["manifests"].append(man)
 
             context["img_prefix"] = regions.get_ref().split("_anno")[0]
             if context["img_nb"] is None:

--- a/front/app/webapp/views/search.py
+++ b/front/app/webapp/views/search.py
@@ -16,9 +16,11 @@ def paginated_records(request, records):
     page_obj = paginator.get_page(page_number)
 
     results = [
-        obj.to_json(request_user=request.user)
+        {**json_obj, "can_edit": obj.can_edit(request.user)}
+        if hasattr(obj, "can_edit")
+        else json_obj
         for obj in page_obj
-        if obj.json is not None
+        if (json_obj := obj.json)
     ]
 
     return {
@@ -29,20 +31,20 @@ def paginated_records(request, records):
     }
 
 
+def get_shared_with(model_class, current_user):
+    if current_user.is_superuser:
+        return model_class.objects.order_by("id")
+    return model_class.objects.filter(
+        Q(user=current_user)
+        | Q(is_public=True)
+        | Q(shared_with__id=current_user.id)
+        | Q(user__groups__in=current_user.groups.all())
+    ).distinct()
+
+
 @require_GET
 def search_witnesses(request):
-    current_user = request.user
-
-    if current_user.is_superuser:
-        witnesses = Witness.objects.order_by("id")
-    else:
-        witnesses = Witness.objects.filter(
-            Q(user=current_user)
-            | Q(is_public=True)
-            | Q(shared_with=current_user)
-            | Q(user__groups__in=current_user.groups.all())
-        ).distinct()
-
+    witnesses = get_shared_with(Witness, request.user)
     witness_filter = WitnessFilter(request.GET, queryset=witnesses)
     return JsonResponse(paginated_records(request, witness_filter.qs))
 
@@ -66,7 +68,8 @@ def search_works(request):
 
 @require_GET
 def search_series(request):
-    series_filter = SeriesFilter(request.GET, queryset=Series.objects.order_by("id"))
+    series = get_shared_with(Series, request.user)
+    series_filter = SeriesFilter(request.GET, queryset=series)
     return JsonResponse(paginated_records(request, series_filter.qs))
 
 

--- a/front/app/webapp/views/search.py
+++ b/front/app/webapp/views/search.py
@@ -17,9 +17,7 @@ def paginated_records(request, records):
 
     results = []
     for obj in page_obj:
-        if json_obj := obj.json:
-            if hasattr(obj, "can_edit"):
-                json_obj = {**json_obj, "can_edit": obj.can_edit(request.user)}
+        if json_obj := obj.get_json(request_user=request.user):
             results.append(json_obj)
 
     return {

--- a/front/app/webapp/views/search.py
+++ b/front/app/webapp/views/search.py
@@ -43,7 +43,7 @@ def get_shared_with(model_class, current_user):
 
 @require_GET
 def search_witnesses(request):
-    witnesses = get_shared_with(Witness, request.user)
+    witnesses = get_shared_with(Witness, request.user).prefetch_related("shared_with")
     witness_filter = WitnessFilter(request.GET, queryset=witnesses)
     return JsonResponse(paginated_records(request, witness_filter.qs))
 
@@ -67,7 +67,7 @@ def search_works(request):
 
 @require_GET
 def search_series(request):
-    series = get_shared_with(Series, request.user)
+    series = get_shared_with(Series, request.user).prefetch_related("shared_with")
     series_filter = SeriesFilter(request.GET, queryset=series)
     return JsonResponse(paginated_records(request, series_filter.qs))
 

--- a/front/app/webapp/views/search.py
+++ b/front/app/webapp/views/search.py
@@ -15,13 +15,12 @@ def paginated_records(request, records):
     page_number = request.GET.get("p", 1)
     page_obj = paginator.get_page(page_number)
 
-    results = [
-        {**json_obj, "can_edit": obj.can_edit(request.user)}
-        if hasattr(obj, "can_edit")
-        else json_obj
-        for obj in page_obj
-        if (json_obj := obj.json)
-    ]
+    results = []
+    for obj in page_obj:
+        if json_obj := obj.json:
+            if hasattr(obj, "can_edit"):
+                json_obj = {**json_obj, "can_edit": obj.can_edit(request.user)}
+            results.append(json_obj)
 
     return {
         "results": results,
@@ -37,7 +36,7 @@ def get_shared_with(model_class, current_user):
     return model_class.objects.filter(
         Q(user=current_user)
         | Q(is_public=True)
-        | Q(shared_with__id=current_user.id)
+        | Q(shared_with=current_user)
         | Q(user__groups__in=current_user.groups.all())
     ).distinct()
 

--- a/front/app/webapp/views/search.py
+++ b/front/app/webapp/views/search.py
@@ -43,7 +43,7 @@ def get_shared_with(model_class, current_user):
 
 @require_GET
 def search_witnesses(request):
-    witnesses = get_shared_with(Witness, request.user).prefetch_related("shared_with")
+    witnesses = get_shared_with(Witness, request.user)
     witness_filter = WitnessFilter(request.GET, queryset=witnesses)
     return JsonResponse(paginated_records(request, witness_filter.qs))
 
@@ -67,7 +67,7 @@ def search_works(request):
 
 @require_GET
 def search_series(request):
-    series = get_shared_with(Series, request.user).prefetch_related("shared_with")
+    series = get_shared_with(Series, request.user)
     series_filter = SeriesFilter(request.GET, queryset=series)
     return JsonResponse(paginated_records(request, series_filter.qs))
 


### PR DESCRIPTION
Small fixes to prevent cascading SQL requests for already indexed records and prevent python errors during data retrieval

I would recommend not indexing at all `can_edit` in the database since it is user-dependent, and only adding it dynamically using `record.get_json(request_user=request.user)`

In the future it would be probably better to replace `record.json.can_edit` with a list of authorized users (e.g. `record.json.authorized_users`) and update the `record.can_edit(request_user)` method to look if the `request_user.id` is in the list of indexed authorized users.
This list of authorized users could be updated on change of `shared_with` field to prevent triggering any additional request when paginating records