### PR TITLE
[FIX] delete regions even if extraction file is missing

### DIFF
--- a/front/app/webapp/views/regions.py
+++ b/front/app/webapp/views/regions.py
@@ -301,8 +301,15 @@ def delete_regions(request, rid):
     regions = get_object_or_404(Regions, id=rid)
     try:
         delete_annotations.delay(regions.get_ref(), regions.get_manifest_url())
+        region_extraction_file = Path(f"{REGIONS_PATH}/{regions.get_ref()}.json")
 
-        Path(f"{REGIONS_PATH}/{regions.get_ref()}.json").unlink()
+        try:
+            region_extraction_file.unlink()
+        except FileNotFoundError:
+            log(
+                f"[delete_regions] Region extraction file for {regions.get_ref()} not found, not deleting it (searched at: {str(region_extraction_file)})"
+            )
+
         delete_api_regions.delay(regions.get_digit().get_ref(), regions.model)
 
         try:


### PR DESCRIPTION
before the fix, if you delete a Region extraction but the region extraction file storing API results is not found, the region can't be deleted.

now, we just log an error message and go on with our lives.