### PR TITLE
[IIIF] improve manifest generation

### DIFF
--- a/front/app/webapp/management/commands/add_img_dimension.py
+++ b/front/app/webapp/management/commands/add_img_dimension.py
@@ -1,0 +1,37 @@
+from django.core.management.base import BaseCommand
+from app.webapp.models.digitization import Digitization
+
+
+class Command(BaseCommand):
+    help = "Fills {name, h, w} dicts into Digitization.json.imgs"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--limit", type=int, default=None)
+
+    def handle(self, *args, **opts):
+        qs = Digitization.objects.exclude(json__imgs__isnull=True)
+        if opts["limit"]:
+            qs = qs[: opts["limit"]]
+
+        stats = {"ok": 0, "skip": 0, "fail": 0}
+        for digit in qs.iterator(chunk_size=50):
+            imgs = (digit.json or {}).get("imgs") or []
+            if imgs and all(
+                isinstance(i, dict) and "h" in i and "w" in i for i in imgs
+            ):
+                stats["skip"] += 1
+                continue
+            try:
+                if opts["dry_run"]:
+                    self.stdout.write(f"would update #{digit.id} ({len(imgs)} imgs)")
+                else:
+                    digit.update_imgs_json(
+                        [i["name"] if isinstance(i, dict) else i for i in imgs]
+                    )
+                stats["ok"] += 1
+            except Exception as e:
+                self.stderr.write(f"#{digit.id}: {e}")
+                stats["fail"] += 1
+
+        self.stdout.write(self.style.SUCCESS(f"{stats}"))

--- a/front/app/webapp/models/digitization.py
+++ b/front/app/webapp/models/digitization.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Optional, List
 
 from iiif_prezi.factory import StructuralError
+from PIL import Image, UnidentifiedImageError
 
 from django.utils.safestring import mark_safe
 from django.core.validators import FileExtensionValidator
@@ -33,7 +34,6 @@ from app.webapp.models.utils.constants import (
     SOURCE_INFO,
 )
 from app.webapp.utils.functions import (
-    delete_files,
     rename_file,
     get_nb_of_files,
     get_first_img,
@@ -46,6 +46,7 @@ from app.webapp.utils.paths import (
     REGIONS_PATH,
     PDF_DIR,
 )
+from webapp.utils.logger import log
 from webapp.utils.paths import TMP_PATH
 
 ALLOWED_EXT = ["jpg", "jpeg", "png", "tif"]
@@ -74,6 +75,18 @@ def no_save(instance, original_filename):
     # NOTE here, digit_id is not yet set, digit files are renamed afterwards
     #  inside temp_to_img() with digit.get_file_path()
     return f"{instance.get_relative_path()}/to_delete.txt"
+
+
+def img_meta(img):
+    if isinstance(img, dict) and "h" in img and "w" in img:
+        return img
+    name = img["name"] if isinstance(img, dict) else img
+    try:
+        with Image.open(f"{IMG_PATH}/{name}") as im:
+            return {"name": name, "h": im.height, "w": im.width}
+    except (UnidentifiedImageError, FileNotFoundError, OSError) as e:
+        log(f"[img_meta] Unreadable image {name}", e)
+        return None
 
 
 class Digitization(AbstractSearchableModel):
@@ -240,8 +253,6 @@ class Digitization(AbstractSearchableModel):
             return True
         return False
 
-    ####### WORK IN PROGRESS
-
     def count_annotations(self):
         from app.webapp.utils.iiif.annotation import get_total_annotations
 
@@ -269,68 +280,93 @@ class Digitization(AbstractSearchableModel):
         """
         return all(region.is_vectorized() for region in self.get_regions())
 
-    ####### WORK IN PROGRESS
-
-    def get_img(self, is_abs=False, only_first=False):
-        if only_first:
-            return get_first_img(self.get_ref())
-        return self.get_imgs(is_abs, only_one=True)
-
-    def get_imgs(self, is_abs=False, temp=False, only_one=False, check_in_dir=False):
+    def get_imgs(
+        self,
+        is_abs=False,
+        temp=False,
+        only_one=False,
+        check_in_dir=False,
+        with_meta=False,
+    ):
+        """
+        Return image filenames or full {name, h, w} dicts (with_meta=True)
+        Reads from self.json.imgs unless check_in_dir/temp
+        """
         if not check_in_dir and not temp:
-            if imgs := self.get_key_value("imgs"):
-                return imgs[0] if only_one else imgs
+            stored = self.get_key_value("imgs") or []
 
-        prefix = f"{self.get_ref()}_" if not temp else f"temp_{self.get_wit_ref()}"
+            if stored and any(
+                not (isinstance(i, dict) and "h" in i and "w" in i) for i in stored
+            ):
+                stored = self.update_imgs_json(stored)
+
+            if stored:
+                entries = stored[:1] if only_one else stored
+                if with_meta:
+                    return entries[0] if only_one else entries
+                return entries[0]["name"] if only_one else [e["name"] for e in entries]
+
+        prefix = f"temp_{self.get_wit_ref()}" if temp else f"{self.get_ref()}_"
         img_dir = TMP_PATH if temp else IMG_PATH
-        path = f"{img_dir}/" if is_abs else ""
-        imgs = sorted(get_files_with_prefix(img_dir, prefix, path, only_one))
-        if not temp:
-            self.update_json(imgs)
-        return imgs
+        names = sorted(get_files_with_prefix(img_dir, prefix, "", only_one))
 
-    def update_imgs_json(self, imgs):
+        if temp:
+            path_prefix = f"{img_dir}/" if is_abs else ""
+            return [f"{path_prefix}{n}" for n in names]
+
+        if not only_one:
+            self.update_imgs_json(names)
+
+        if with_meta:
+            imgs = [e for e in (img_meta(n) for n in names) if e]
+            return imgs[0] if only_one else imgs
+        return names[0] if only_one else names
+
+    def update_imgs_json(self, imgs=None):
         """
-        Add or update the properties related to images in the JSON representation of the digitization.
-        :param imgs: list of image filenames (⚠ no absolute path!)
+        Merge new image filenames in self.json.imgs in a list of {name, h, w}
         """
-        if type(imgs) is not list:
+        if not isinstance(imgs, list):
             imgs = get_files_with_prefix(IMG_PATH, f"{self.get_ref()}_", "")
 
-        if not self.is_key_defined("imgs"):
-            self.json["imgs"] = []
+        existing = {}
+        for item in (self.json or {}).get("imgs", []):
+            if (
+                isinstance(item, dict)
+                and "name" in item
+                and "h" in item
+                and "w" in item
+            ):
+                existing[item["name"]] = item
 
-        # only unique filenames
-        all_imgs = sorted(
-            list(set([os.path.basename(img) for img in self.json["imgs"] + imgs]))
-        )
+        for i in imgs:
+            if isinstance(i, dict) and "h" in i and "w" in i:
+                existing.setdefault(i["name"], i)
 
-        self.json["imgs"] = all_imgs
-        self.json["img_nb"] = len(self.json["imgs"])
-        self.json["zeros"] = self.img_zeros(self.json["imgs"][0])
+        new = {os.path.basename(i["name"] if isinstance(i, dict) else i) for i in imgs}
+        names = sorted(new | set(existing))
+
+        images = [e for e in (existing.get(n) or img_meta(n) for n in names) if e]
+
+        if self.json is None:
+            self.json = {}
+        self.json["imgs"] = images
+        self.json["img_nb"] = len(images)
+        self.json["zeros"] = self.img_zeros(images[0]["name"]) if images else 0
         self.update(json=self.json)
-
-    def update_json(self, imgs=Optional[List[str]]):
-        if not imgs:
-            imgs = sorted(get_files_with_prefix(IMG_PATH, f"{self.get_ref()}_", ""))
-
-        json_data = {
-            "id": self.id,
-            "title": self.__str__(),
-            "ref": self.get_ref(),
-            "class": self.__class__.__name__,
-            "type": get_name("Digitization"),
-            "url": self.get_manifest_url(),
-            "imgs": imgs,
-            "img_nb": len(imgs),
-            "zeros": self.img_zeros(imgs[0] if len(imgs) > 0 else 0),
-        }
-        type(self).objects.filter(pk=self.pk.__str__()).update(json=json_data)
-        return self.json
+        return images
 
     def to_json(self, reindex=True, no_img=False):
         djson = self.json or {}
-        imgs = djson.get("imgs", [] if no_img else self.get_imgs(check_in_dir=True))
+        if no_img:
+            imgs = djson.get("imgs", [])
+            img_nb = djson.get("img_nb", 0)
+            zeros = djson.get("zeros", 0)
+        else:
+            imgs = djson.get("imgs") or self.get_imgs(check_in_dir=True, with_meta=True)
+            img_nb = djson.get("img_nb") or len(imgs)
+            zeros = djson.get("zeros") or self.img_zeros(check_in_dir=reindex)
+
         return {
             "id": self.id,
             "title": self.__str__(),
@@ -339,10 +375,8 @@ class Digitization(AbstractSearchableModel):
             "type": get_name("Digitization"),
             "url": self.get_manifest_url(),
             "imgs": imgs,
-            "img_nb": djson.get("img_nb", len(imgs)),
-            "zeros": djson.get(
-                "zeros", 0 if no_img else self.img_zeros(check_in_dir=reindex)
-            ),
+            "img_nb": img_nb,
+            "zeros": zeros,
         }
 
     def get_metadata(self):

--- a/front/app/webapp/models/digitization.py
+++ b/front/app/webapp/models/digitization.py
@@ -328,7 +328,7 @@ class Digitization(AbstractSearchableModel):
         type(self).objects.filter(pk=self.pk.__str__()).update(json=json_data)
         return self.json
 
-    def to_json(self, reindex=True, no_img=False, request_user=None):
+    def to_json(self, reindex=True, no_img=False):
         djson = self.json or {}
         imgs = djson.get("imgs", [] if no_img else self.get_imgs(check_in_dir=True))
         return {

--- a/front/app/webapp/models/document_set.py
+++ b/front/app/webapp/models/document_set.py
@@ -215,7 +215,7 @@ class DocumentSet(AbstractSearchableModel):
             type(self).objects.filter(pk=self.pk).update(selection=json_data)
         return self.selection
 
-    def to_json(self, reindex=True, no_img=False, request_user=None):
+    def to_json(self, reindex=True, no_img=False):
         user = self.user
         try:
             return json_encode(

--- a/front/app/webapp/models/regions.py
+++ b/front/app/webapp/models/regions.py
@@ -140,7 +140,7 @@ class Regions(AbstractSearchableModel):
             return metadata
         return {}
 
-    def to_json(self, reindex=True, no_img=False, request_user=None):
+    def to_json(self, reindex=True, no_img=False):
         """
         Do not take into account no_img for regions because there is no post_save task as for Digitization
         to fill image related properties

--- a/front/app/webapp/models/searchable_models.py
+++ b/front/app/webapp/models/searchable_models.py
@@ -38,12 +38,11 @@ class AbstractSearchableModel(models.Model):
     def get_absolute_view_url(self):
         raise NotImplementedError("Subclasses must implement this method")
 
-    def to_json(self, reindex=True, no_img=False, request_user=None):
+    def to_json(self, reindex=True, no_img=False):
         """
         reindex and no_img are used in subclasses to_json methods
         reindex: force recomputing all properties, even the one that require intensive computation
         no_img: if True, do not index image related property
-        TODO delete request_user (should only be handled by get_json and not persisted in db)
         """
         try:
             return json_encode(
@@ -78,8 +77,7 @@ class AbstractSearchableModel(models.Model):
         If request_user is provided, enrich with can_edit without reindexing.
         """
         if not self.json or reindex:
-            # NOTE to_json should probably not use request_user to not index in db can_edit value which is user-dependant
-            json_data = self.to_json(reindex=True, request_user=request_user)
+            json_data = self.to_json(reindex=True)
             self.update_json(json_data)
             return json_data
 

--- a/front/app/webapp/models/series.py
+++ b/front/app/webapp/models/series.py
@@ -111,7 +111,7 @@ class Series(AbstractSearchableModel):
             or user.groups.filter(user=self.user).exists()
         )
 
-    def to_json(self, reindex=True, no_img=False, request_user=None):
+    def to_json(self, reindex=True, no_img=False):
         library = self.place
         pub_place = self.get_edition_place()
         publisher = self.get_publisher()
@@ -124,7 +124,6 @@ class Series(AbstractSearchableModel):
                 "type": get_name("Series"),
                 "edit_url": self.get_absolute_edit_url(),
                 "view_url": self.get_absolute_view_url(),
-                "can_edit": self.can_edit(request_user),
                 "title": self.__str__(),
                 "user": user.__str__() if user else NO_USER,
                 "user_id": user.id if user else 0,

--- a/front/app/webapp/models/treatment.py
+++ b/front/app/webapp/models/treatment.py
@@ -156,7 +156,7 @@ class Treatment(AbstractSearchableModel):
             urls = [f"{url}?tab={tabs[self.task_type]}" for url in urls]
         return urls
 
-    def to_json(self, reindex=True, no_img=False, request_user=None):
+    def to_json(self, reindex=True, no_img=False):
         try:
             user = self.requested_by
             doc_set = self.document_set

--- a/front/app/webapp/models/witness.py
+++ b/front/app/webapp/models/witness.py
@@ -385,12 +385,11 @@ class Witness(AbstractSearchableModel):
     def is_vectorized(self):
         return any(digit.is_vectorized() for digit in self.get_digits())
 
-    def get_img(self, is_abs=False, only_first=False):
+    def get_img(self, is_abs=False):
         # to get only one image of the witness
         for digit in self.get_digits():
-            if img := digit.get_img(is_abs, only_first):
+            if img := digit.get_imgs(is_abs, only_one=True):
                 return img
-
         return None
 
     def get_imgs(self, is_abs=False, temp=False, check_in_dir=False):

--- a/front/app/webapp/models/witness.py
+++ b/front/app/webapp/models/witness.py
@@ -189,7 +189,7 @@ class Witness(AbstractSearchableModel):
             or user.groups.filter(user=self.user).exists()
         )
 
-    def to_json(self, reindex=True, no_img=False, request_user=None):
+    def to_json(self, reindex=True, no_img=False):
         buttons = {"regions": reverse("webapp:witness_regions_view", args=[self.id])}
 
         digits = self.get_digits()
@@ -217,8 +217,6 @@ class Witness(AbstractSearchableModel):
                 "user": user.__str__() if user else NO_USER,
                 "edit_url": self.get_absolute_edit_url(),
                 "view_url": self.get_absolute_view_url(),
-                # NOTE handled dynamically by the get_json method in SearchableModel
-                "can_edit": self.can_edit(request_user),
                 "updated_at": updated,
                 "is_public": self.is_public,
                 "metadata": {

--- a/front/app/webapp/models/work.py
+++ b/front/app/webapp/models/work.py
@@ -88,7 +88,7 @@ class Work(AbstractSearchableModel):
 
         return f"{base_url}?{query_string}"
 
-    def to_json(self, reindex=True, no_img=False, request_user=None):
+    def to_json(self, reindex=True, no_img=False):
         place = self.place
         author = self.author
         return json_encode(
@@ -96,8 +96,6 @@ class Work(AbstractSearchableModel):
                 "id": self.id,
                 "class": self.__class__.__name__,
                 "type": get_name("Work"),
-                # "user": self.user.__str__(),
-                # "user_id": self.user.id,
                 "edit_url": self.get_absolute_edit_url(),
                 "view_url": self.get_absolute_view_url(),
                 "can_edit": True,

--- a/front/app/webapp/tasks.py
+++ b/front/app/webapp/tasks.py
@@ -132,6 +132,7 @@ def update_image_json(img_list, digit_id):
         digit.update_imgs_json(img_list)
 
         witness = digit.witness
+        # reindex to add first image to witness metadata
         witness.get_json(reindex=True)
 
         return True

--- a/front/app/webapp/utils/iiif/annotation.py
+++ b/front/app/webapp/utils/iiif/annotation.py
@@ -1,7 +1,6 @@
 import colorsys
 import hashlib
 import json
-import re
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
@@ -171,33 +170,6 @@ def get_annotation_tags(anno: Dict) -> List[str]:
     if isinstance(resources, dict):
         resources = [resources]
     return [r.get("chars") for r in resources if r.get("@type") == "oa:Tag"]
-
-
-def set_canvas(seq, canvas_nb, img_name, img):
-    """
-    Build the canvas and annotation for each image
-    Called for each manifest (v2: corrected annotations) image when a witness is being indexed
-    """
-    try:
-        h, w = int(img["height"]), int(img["width"])
-    except TypeError:
-        h, w = img.height, img.width
-    except ValueError:
-        h, w = 900, 600
-    # Build the canvas
-    canvas = seq.canvas(ident=f"c{canvas_nb}", label=f"Page {canvas_nb}")
-    canvas.set_hw(h, w)
-
-    # Build the image annotation
-    annotation = canvas.annotation(ident=f"a{canvas_nb}")
-    if re.match(r"https?://(.*?)/", img_name):
-        # to build hybrid manifest referencing images from other IIIF repositories
-        img = annotation.image(img_name, iiif=False)
-        setattr(img, "format", "image/jpeg")
-    else:
-        img = annotation.image(ident=img_name, iiif=True)
-
-    img.set_hw(h, w)
 
 
 def get_coord_from_annotation(aiiinotation, as_str=False):

--- a/front/app/webapp/utils/iiif/download.py
+++ b/front/app/webapp/utils/iiif/download.py
@@ -12,4 +12,8 @@ def iiif_to_img(manifest_url, digit_ref, digit):
     manifest = IIIFManifest(manifest_url, prefix=f"{digit_ref}_")
     manifest.download(save_dir=IMG_PATH)
     digit.add_info(manifest.license)
-    return [img.img_path for img in manifest.images]
+    return [
+        {"name": img.img_path, "h": img.height, "w": img.width}
+        for img in manifest.images
+    ]
+    # return [img.img_path for img in manifest.images]

--- a/front/app/webapp/utils/iiif/manifest.py
+++ b/front/app/webapp/utils/iiif/manifest.py
@@ -17,12 +17,8 @@ from app.webapp.utils.logger import console, log
 
 
 def set_canvas(seq, canvas_nb, img_name, img):
-    """
-    Build the canvas and annotation for each image
-    Called for each manifest (v2: corrected annotations) image when a witness is being indexed
-    """
     try:
-        h, w = int(img["height"]), int(img["width"])
+        h, w = int(img["h"]), int(img["w"])
     except TypeError:
         h, w = img.height, img.width
     except ValueError:
@@ -31,6 +27,7 @@ def set_canvas(seq, canvas_nb, img_name, img):
     canvas = seq.canvas(ident=f"c{canvas_nb}", label=f"Page {canvas_nb}")
     canvas.set_hw(h, w)
 
+    # TODO needed???
     # Build the image annotation
     annotation = canvas.annotation(ident=f"a{canvas_nb}")
     if re.match(r"https?://(.*?)/", img_name):
@@ -77,7 +74,7 @@ def process_images(digit, seq):
     Process the images of a witness and add them to a sequence
     """
     try:
-        imgs = digit.get_imgs(is_abs=False)
+        imgs = digit.get_imgs(is_abs=False, with_meta=True)
         if len(imgs) == 0:
             log(f"[process_images] No images for Digitization n°{digit.id}")
             return False

--- a/front/app/webapp/utils/iiif/manifest.py
+++ b/front/app/webapp/utils/iiif/manifest.py
@@ -1,3 +1,5 @@
+import re
+
 from PIL import Image, UnidentifiedImageError
 from iiif_prezi.factory import ManifestFactory
 
@@ -10,9 +12,35 @@ from app.webapp.utils.paths import IMG_PATH
 from app.config.settings import CANTALOUPE_APP_URL, APP_URL
 
 from app.webapp.utils.logger import console, log
-from app.webapp.utils.iiif.annotation import set_canvas
 
 # NOTE img name = "{wit_abbr}{wit_id}_{digit_abbr}{digit_id}_{canvas_nb}.jpg"
+
+
+def set_canvas(seq, canvas_nb, img_name, img):
+    """
+    Build the canvas and annotation for each image
+    Called for each manifest (v2: corrected annotations) image when a witness is being indexed
+    """
+    try:
+        h, w = int(img["height"]), int(img["width"])
+    except TypeError:
+        h, w = img.height, img.width
+    except ValueError:
+        h, w = 900, 600
+    # Build the canvas
+    canvas = seq.canvas(ident=f"c{canvas_nb}", label=f"Page {canvas_nb}")
+    canvas.set_hw(h, w)
+
+    # Build the image annotation
+    annotation = canvas.annotation(ident=f"a{canvas_nb}")
+    if re.match(r"https?://(.*?)/", img_name):
+        # to build hybrid manifest referencing images from other IIIF repositories
+        img = annotation.image(img_name, iiif=False)
+        setattr(img, "format", "image/jpeg")
+    else:
+        img = annotation.image(ident=img_name, iiif=True)
+
+    img.set_hw(h, w)
 
 
 def get_meta(metadatum, meta_type="label"):
@@ -44,33 +72,29 @@ def get_meta_value(metadatum, label: str):
     return get_meta(metadatum, "value")
 
 
-def process_images(obj, seq):
+def process_images(digit, seq):
     """
-    obj: Digitization | Regions
     Process the images of a witness and add them to a sequence
     """
-    class_name = obj.__class__.__name__
-
     try:
-        imgs = obj.get_imgs(is_abs=False)
+        imgs = digit.get_imgs(is_abs=False)
         if len(imgs) == 0:
-            log(f"[process_images] No images for {class_name} n°{obj.id}")
+            log(f"[process_images] No images for Digitization n°{digit.id}")
             return False
 
         for counter, img in enumerate(imgs, start=1):
-            try:
-                set_canvas(
-                    seq,
-                    counter,
-                    img,
-                    Image.open(f"{IMG_PATH}/{img}"),
-                )
-            except UnidentifiedImageError as e:
-                log(f"[process_images] Unable to retrieve {img}", e)
-            except FileNotFoundError as e:
-                log(f"[process_images] Non existing {img}", e)
+            if isinstance(img, dict):
+                set_canvas(seq, counter, img["name"], img)
+            else:
+                try:
+                    set_canvas(seq, counter, img, Image.open(f"{IMG_PATH}/{img}"))
+                except (UnidentifiedImageError, FileNotFoundError) as e:
+                    log(f"[process_images] Error processing {img}", e)
     except Exception as e:
-        log(f"[process_images] Couldn't retrieve images for {class_name} n°{obj.id}", e)
+        log(
+            f"[process_images] Couldn't retrieve images for Digitization n°{digit.id}",
+            e,
+        )
         return False
     return True
 

--- a/front/app/webapp/views/regions.py
+++ b/front/app/webapp/views/regions.py
@@ -24,10 +24,8 @@ from app.webapp.utils.iiif.annotation import (
     index_regions,
     destroy_regions,
     process_regions,
-    formatted_annotations,
     reindex_file,
     get_regions_urls,
-    get_record_annotations,
 )
 from app.webapp.utils.regions import (
     get_regions_img,


### PR DESCRIPTION
Before, in order to generate any manifest, we had to open each manifest image in order to get its dimension; super duper inefficient!

Now, the Digitization.json index stores images as sets of metadata:
- Before: `digit.json.imgs = [filename1, filename2, ...]
- After: `digit.json.imgs = [{name: filename1, w: w, h: h}, {name: filename2, w: w, h: h}, ...]

This extra info is either generated and stored on the fly when it is needed, or generated once with `venv/bin/python front/app/manage.py add_img_dimension`.

For newly added digitization, evrything should be handled after import.

Voilà 😚