### PR TITLE
FIX: mirador urls + witness.get_img

### DIFF
--- a/front/app/webapp/models/witness.py
+++ b/front/app/webapp/models/witness.py
@@ -197,7 +197,7 @@ class Witness(AbstractSearchableModel):
 
         img = self.get_key_value("img")
         if not no_img and (reindex or not img):
-            img = self.get_img(only_first=True)
+            img = self.get_img()
 
         updated = (
             self.updated_at.strftime("%Y-%m-%d %H:%M") if self.updated_at else None

--- a/front/app/webapp/static/js/script.js
+++ b/front/app/webapp/static/js/script.js
@@ -143,7 +143,6 @@ function validateRegions(regions_ref = null) {
         fetch(`${APP_URL}/${APP_NAME}/iiif/validate/${regions_ref}`)
             .then(response => {
                 if (response.status === 200) {
-                    // window.replace(`${AIIINOTATE_BASE_URL}/indexView.html?iiif-content=${toManifest(witId, witType, "v2")}`);
                     try { window.replace(`${APP_URL}/${APP_NAME}-admin/${WEBAPP_NAME}/witness`); }
                     catch(e) { window.location = `${APP_URL}/${APP_NAME}-admin/${WEBAPP_NAME}/witness`; }
                 } else {

--- a/front/app/webapp/utils/iiif/gen_html.py
+++ b/front/app/webapp/utils/iiif/gen_html.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from app.webapp.models.digitization import Digitization
 from app.webapp.utils.functions import get_icon, get_action, cls
 from app.config.settings import (
+    MIRADOR_BASE_URL,
     AIIINOTATE_BASE_URL,
     APP_URL,
     APP_NAME,
@@ -23,11 +24,11 @@ def regions_btn(obj, action="view"):
     if action == "view":
         icon = get_icon("eye")
         # The link redirects to Mirador with no regions (Digitization) or automatic regions (Regions)
-        link = f"{AIIINOTATE_BASE_URL}/indexView.html?iiif-content={obj.get_manifest_url()}"
+        link = f"{MIRADOR_BASE_URL}/index.html?iiif-content={obj.get_manifest_url()}"
     elif action == "auto-view":
         icon = get_icon("eye")
         # The link redirects to Mirador with no regions (Digitization) or automatic regions (Regions)
-        link = f"{AIIINOTATE_BASE_URL}/indexView.html?iiif-content={obj.get_manifest_url()}"
+        link = f"{MIRADOR_BASE_URL}/index.html?iiif-content={obj.get_manifest_url()}"
     # elif action == "edit":
     #     icon = get_icon("pen-to-square")
     #     # The link redirects to the edit regions page (show_regions() view DELETED)
@@ -35,7 +36,7 @@ def regions_btn(obj, action="view"):
     elif action == "final":
         icon = get_icon("check")
         # The link redirects to Mirador with corrected regions (Regions)
-        link = f"{AIIINOTATE_BASE_URL}/indexView.html?iiif-content={obj.get_manifest_url()}"
+        link = f"{MIRADOR_BASE_URL}/index.html?iiif-content={obj.get_manifest_url()}"
     # elif action == "similarity":
     #     icon = get_icon("code-compare")
     #     link = f"{APP_URL}/{APP_NAME}/{obj.get_ref()}/show-similarity"


### PR DESCRIPTION
aiiinotate and mirador are now fully autonomous (=/= SAS) => use MIRADOR_BASE_URL for mirador URLs 