### PR TITLE
[FIX] fix docker-to-host requests (in part at least)

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -7,6 +7,10 @@ x-proxy: &proxy
   HTTPS_PROXY: ${HTTPS_PROXY:-}
   NO_PROXY: localhost,127.0.0.1,web,nginx,db,redis,mongo,cantaloupe,aiiinotate,mirador
 
+x-extra-hosts: &extra-hosts
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+
 services:
   db:
     image: postgres:14
@@ -70,11 +74,10 @@ services:
       args:
         PORT: ${AIIINOTATE_PORT}
         ENV_PATH: app/config/.env
+    <<: *extra-hosts
     # runtime env wins over the .env baked at build time (dotenvx does not
     # override variables already present in the environment)
     env_file: .env
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     depends_on:
       mongo:
         condition: service_healthy
@@ -90,9 +93,8 @@ services:
       args:
         PORT: ${MIRADOR_PORT}
         ENV_PATH: app/config/.env
+    <<: *extra-hosts
     env_file: .env
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     depends_on:
       - aiiinotate
     networks: [aikon]
@@ -113,8 +115,6 @@ services:
     volumes:
       - ${DATA_FOLDER}:/data
       - staticfiles:/home/aikon/app/staticfiles
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     depends_on:
       db:
         condition: service_healthy

--- a/front/app/webapp/utils/iiif/annotation.py
+++ b/front/app/webapp/utils/iiif/annotation.py
@@ -35,7 +35,8 @@ IIIF_PRESENTATION_VERSION = 2
 
 
 def dockerize(url: str) -> str:
-    return url.replace(APP_URL, APP_URL_FROM_DOCKER)
+    # return url.replace(APP_URL, APP_URL_FROM_DOCKER)
+    return url.replace(APP_URL, " http://host.docker.internal:8000")
 
 
 def update_params(urlstr: str, q_params: Dict) -> str:

--- a/install.py
+++ b/install.py
@@ -30,8 +30,8 @@ UV_INSTALL = {
 }
 
 
-def sh(cmd: list, cwd: Path = None) -> None:
-    subprocess.run(cmd, cwd=cwd, check=True)
+def sh(cmd: list|str, cwd: Path = None, shell = False, capture_output = False, text = False) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=capture_output, shell=shell, text=text)
 
 
 def which(name: str) -> str:
@@ -115,6 +115,29 @@ def setup_api(mode: str, use_defaults: bool) -> None:
     ] + (["--defaults"] if use_defaults else [])
     sh(cmd, cwd=ROOT / "api")
 
+def detect_firewall() -> None:
+    """
+    firewalls can silently cause docker-to-host HTTP requests to fail.
+    detect if a firewall is used, and if so print an error message.
+    MacOS is not concerned: firewall is disabled by default and Docker-to-Host
+    queries are not blocked by its firewall (socketfilterfw)
+    """
+    script = f"bash {ROOT / 'scripts' / 'check_firewall.sh'}"
+    msg = lambda firewall: print(
+        "\n"
+        f"⚠️  Detected active firewall `{firewall}`, "
+        "which may cause network errors (Docker-to-Host requests blocked.) "
+        "Run the following script to add Docker's network to firewall:\n"
+        f">>> {script}\n"
+    )
+    _sh = lambda cmd: sh(cmd, cwd=ROOT, shell=True, capture_output=True, text=True)
+    # 1. ubuntu/debian
+    if which("ufw") and "Status: active" in _sh("sudo ufw status").stdout:
+        msg("ufw")
+    # 2. fedora
+    elif which("firewall-cmd") and "running" in _sh("firewall-cmd --state").stdout:
+        msg("firewalld")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
@@ -128,3 +151,5 @@ if __name__ == "__main__":
 
     (setup_dev if mode == "dev" else setup_docker)(v)
     setup_api(mode, args.defaults)
+
+    detect_firewall()

--- a/install.py
+++ b/install.py
@@ -122,13 +122,13 @@ def detect_firewall() -> None:
     MacOS is not concerned: firewall is disabled by default and Docker-to-Host
     queries are not blocked by its firewall (socketfilterfw)
     """
-    script = f"bash {ROOT / 'scripts' / 'check_firewall.sh'}"
+    script_path = f"bash {ROOT / 'scripts' / 'check_firewall.sh'}"
     msg = lambda firewall: print(
         "\n"
         f"⚠️  Detected active firewall `{firewall}`, "
         "which may cause network errors (Docker-to-Host requests blocked.) "
         "Run the following script to add Docker's network to firewall:\n"
-        f">>> {script}\n"
+        f">>> {script_path}\n"
     )
     _sh = lambda cmd: sh(cmd, cwd=ROOT, shell=True, capture_output=True, text=True)
     # 1. ubuntu/debian

--- a/run.py
+++ b/run.py
@@ -32,8 +32,9 @@ WIN = os.name == "nt"
 VENV_BIN = FRONT / "app/.venv" / ("Scripts" if WIN else "bin")
 DEV_PROCS = [
     (
+        # NOTE: runserver on 0.0.0.0: 127.0.0.1 is only for the host's loopback, 0.0.0.0 can be accessed from the docker-compose bridge network
         "django",
-        ["uv", "run", "manage.py", "runserver", "localhost:{FRONT_PORT}"],
+        ["uv", "run", "manage.py", "runserver", "0.0.0.0:{FRONT_PORT}"],
         FRONT / "app",
     ),
     (

--- a/scripts/check_firewall.sh
+++ b/scripts/check_firewall.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# for Linux distros, check for active firewalls. they may silently
+# block connexions from the Docker subnet to the host, which is
+# necessary for Docker containers to be able to interact with the
+# Django app through HTTP. this script adds the Docker subnet to
+# supported firewalls. useful for Debian, Ubuntu and Fedora.
+#
+# this should not be necessary on MacOS: macOS's Application Firewall (socketfilterfw)
+# operates on application-level, not on IP/subnet/port-level. the
+# `host.docker.internal` is managed by a single app (Docker), and MacOS
+# does not block by default the container-to-host queries (as opposed to Linux).
+#
+# THIS ASSUMES the docker-compose is running.
+#
+# USAGE: bash check_firewall.sh
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DOCKER_DIR="$CUR_DIR"/../docker
+ENV_FILE="$CUR_DIR/../front/app/config/.env"
+
+source $ENV_FILE
+
+# jq is a JSON parser in basj
+if ! command -v jq &> /dev/null;
+then sudo apt install jq;
+fi;
+
+# get docker network's subnet
+# this can also be done through `docker compose` but requires the docker-compose
+# and network to be active, and they are inactive in `install.py`.
+# this alternative just parses the Docker-compose's config file/
+cd "$DOCKER_DIR";
+DOCKER_NETWORK=$(docker network ls \
+  --filter label=com.docker.compose.project=aikon \
+  --filter label=com.docker.compose.network=aikon \
+  --format '{{.Name}}')
+DOCKER_SUBNET=$(docker network inspect "$DOCKER_NETWORK" --format '{{(index .IPAM.Config 0).Subnet}}')
+
+# 1. if we have an ufw firewall (enabled by default on Debian/Ubuntu)
+# allow the Docker subnet in the firewall
+if command -v ufw &> /dev/null && sudo ufw status | grep -q "Status: active"; then
+  echo "Detected active ufw firewall — this commonly blocks Docker bridge traffic."
+  echo "Allowing the subnet in ufw..."
+  sudo ufw allow in from "$DOCKER_SUBNET" to any port "$FRONT_PORT"
+
+# 2. if we have firewalld (Fedora),
+# allow the Docker subnet in the firewall
+elif command -v firewall-cmd &> /dev/null && sudo firewall-cmd --state 2>/dev/null | grep -q running; then
+    echo "Detected active firewalld — may be blocking Docker bridge traffic."
+    echo "Allowing the subnet in firewalld..."
+    sudo firewall-cmd --permanent --zone=trusted --add-source="$DOCKER_SUBNET"
+    sudo firewall-cmd --reload
+fi

--- a/scripts/generate_env.py
+++ b/scripts/generate_env.py
@@ -176,27 +176,33 @@ def derive(v: dict, mode: str, in_docker: bool) -> dict:
             else f"http://web:8000" if in_docker
             else f"http://host.docker.internal:{v['FRONT_PORT']}"
         ),
-        "ALLOWED_HOSTS": "localhost,127.0.0.1,0.0.0.0,web,nginx,host.docker.internal",
         "API_URL": v["PROD_API_URL"] if prod else f"http://{'api' if in_docker else 'localhost'}:{v['API_PORT']}",
         "CANTALOUPE_BASE_URI": base if nginx else f"http://localhost:{v['CANTALOUPE_PORT']}",
         "AIIINOTATE_BASE_URL": f"{base}/aiiinotate" if prod else f"http://{host('aiiinotate')}:{v['AIIINOTATE_PORT']}",
-        "AIIINOTATE_HOST": "0.0.0.0",
-        "AIIINOTATE_SCHEME": "http",
-        "AIIINOTATE_LOG_DIR": "/aiiinotate/logs",
         "AIIINOTATE_PUBLIC_URL": f"{base}/aiiinotate" if prod else f"http://localhost:{v['AIIINOTATE_PORT']}",
         "MIRADOR_BASE_URL": f"{base}/mirador" if nginx else f"http://localhost:{v['MIRADOR_PORT']}",
         "MONGODB_CONNSTRING": f"mongodb://{host('mongo')}:{port('MONGODB_PORT')}/{v['MONGODB_DB']}",
         "MONGODB_DB_TEST": f"{v['MONGODB_DB']}_test",
         "MONGODB_CONNSTRING_TEST": f"mongodb://{host('mongo')}:{port('MONGODB_PORT')}/{v['MONGODB_DB']}_test",
-    }
 
+        # TODO : move these to a defaults dict.
+        "ALLOWED_HOSTS": "localhost,127.0.0.1,0.0.0.0,web,nginx,host.docker.internal",
+        "AIIINOTATE_HOST": "0.0.0.0",
+        "AIIINOTATE_SCHEME": "http",
+        "AIIINOTATE_LOG_TARGET": "stdout",
+        "AIIINOTATE_LOG_DIR": "",
+        "AIIINOTATE_LOG_LEVEL": "debug",
+        "AIIINOTATE_PAGE_SIZE": "5000",
+        "AIIINOTATE_STRICT_MODE": "true"  # in lowercase to be properly parsed by aiiinotate's JS
+    }
 
 REQUIRED = {
     "front/app/config/.env": (
         "SECRET_KEY", "POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD",
         "DB_HOST", "DB_PORT", "REDIS_HOST", "REDIS_PORT",
         "API_URL", "BASE_URL", "MEDIA_DIR", "CANTALOUPE_BASE_URI",
-        "AIIINOTATE_BASE_URL", "MIRADOR_BASE_URL",
+        "AIIINOTATE_BASE_URL", "AIIINOTATE_LOG_TARGET", "AIIINOTATE_LOG_LEVEL",
+        "AIIINOTATE_STRICT_MODE", "MIRADOR_BASE_URL",
     ),
     "front/cantaloupe/.env": (
         "CANTALOUPE_BASE_URI", "CANTALOUPE_IMG",
@@ -206,7 +212,7 @@ REQUIRED = {
         "DATA_FOLDER", "USERID", "COMPOSE_FILE",
         "MONGODB_HOST", "MONGODB_PORT", "MONGODB_DB", "MONGODB_CONNSTRING",
         "AIIINOTATE_PORT", "AIIINOTATE_HOST", "AIIINOTATE_SCHEME",
-        "AIIINOTATE_LOG_DIR", "AIIINOTATE_LOG_TARGET", "AIIINOTATE_LOG_LEVEL",
+        "AIIINOTATE_LOG_TARGET", "AIIINOTATE_LOG_LEVEL",
         "AIIINOTATE_PAGE_SIZE", "AIIINOTATE_PUBLIC_URL", "AIIINOTATE_BASE_URL",
         "MIRADOR_PORT", "CANTALOUPE_PORT", "NGINX_PORT",
         "NGINX_MAX_BODY_SIZE", "NGINX_TIMEOUT",

--- a/scripts/generate_env.py
+++ b/scripts/generate_env.py
@@ -176,7 +176,7 @@ def derive(v: dict, mode: str, in_docker: bool) -> dict:
             else f"http://web:8000" if in_docker
             else f"http://host.docker.internal:{v['FRONT_PORT']}"
         ),
-        "ALLOWED_HOSTS": "localhost,127.0.0.1,web,nginx,host.docker.internal",
+        "ALLOWED_HOSTS": "localhost,127.0.0.1,0.0.0.0,web,nginx,host.docker.internal",
         "API_URL": v["PROD_API_URL"] if prod else f"http://{'api' if in_docker else 'localhost'}:{v['API_PORT']}",
         "CANTALOUPE_BASE_URI": base if nginx else f"http://localhost:{v['CANTALOUPE_PORT']}",
         "AIIINOTATE_BASE_URL": f"{base}/aiiinotate" if prod else f"http://{host('aiiinotate')}:{v['AIIINOTATE_PORT']}",


### PR DESCRIPTION
## THE FIX

actual fixes:

- `runserver` on `0.0.0.0` instead of `127.0.0.1` so that it can be accessed by the Docker network
- fix the use of `http://host.docker.internal:8000`

setup & scripts:
- check for firewalls in `install.py`
- create a script to add Docker compose's subnet to firewalls (supported OS's: Debian, Ubuntu and Fedora ; not needed for MacOS)
- fix errors in .env's aiiinotate defaults

## WHAT WORKS AND WHAT DOESN'T

- search-by-canvas works: http://localhost:4444/annotations/2/search?canvasUri=http://localhost:8000/aikon/iiif/wit1_pdf1/canvas/c1.json
- search-api partially: 
  - the base search-api works: http://localhost:4444/search-api/1/manifests/wit1_pdf1/search
  - adding canvasMin and canvasMax doesn't, because canvases are undefined http://localhost:4444/search-api/1/manifests/wit1_pdf1/search?onlyIds=false&canvasMin=0&canvasMax=10
  - => TODO: set AIIINOTATE_STRICT_MODE to true, and fix the fetching of canvasIdx (99% sure it's a problem of AIKON setting the wrong manifest URLs). 

## NOTES

- regions are now displayed in Mirador (client-side fetch to aiiinotate), not in AIKON (server-side fetch to aiiinotate).
- on Ubuntu/Debian OS's, we also need to allow the docker-compose's network on the UFW firewall, otherwise there's a silent error and requests from Docker to Host will just idle. Fixed in `scripts/check_firewall.sh`.